### PR TITLE
Fix SSR and prevent hydrate issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ const markup = renderToString(
     guessedBreakpoint={guessedBreakpoint}
     breakpoints={breakpoints}
   >
-    <App/>
-  </ReactBreakpoints>
+    <App />
+  </ReactBreakpoints>,
 )
 ```
 

--- a/modules/ReactBreakpoints.js
+++ b/modules/ReactBreakpoints.js
@@ -49,8 +49,14 @@ class ReactBreakpoints extends React.Component {
   }
   state = {
     breakpoints: this.props.breakpoints || {},
-    screenWidth: this.props.guessedBreakpoint || this.props.defaultBreakpoint,
-    currentBreakpoint: null,
+    screenWidth: global.window
+      ? global.window.innerWidth
+      : this.props.defaultBreakpoint,
+    currentBreakpoint: global.window
+      ? this.calculateCurrentBreakpoint(global.window.innerWidth)
+      : this.props.guessedBreakpoint
+        ? this.calculateCurrentBreakpoint(this.props.guessedBreakpoint)
+        : null,
   }
 
   componentDidMount() {
@@ -60,11 +66,7 @@ class ReactBreakpoints extends React.Component {
     if (typeof this.props.breakpoints !== 'object')
       throw new Error(ERRORS.NOT_OBJECT)
 
-    this.props.breakpoints !== this.state.breakpoints &&
-      this.setState({ breakpoints: this.props.breakpoints })
-
     if (typeof window !== 'undefined') {
-
       this.readWidth() // initial width calculation
 
       if (this.props.debounceResize) {
@@ -93,11 +95,11 @@ class ReactBreakpoints extends React.Component {
   }
   calculateCurrentBreakpoint(screenWidth) {
     let currentBreakpoint = null
-    const breakpointKeys = Object.keys(this.state.breakpoints)
+    const breakpointKeys = Object.keys(this.props.breakpoints)
     new Array(...breakpointKeys)
       .reverse() // reverse array to put largest breakpoint first
       .map(breakpoint => {
-        const breakpointPixelValue = this.state.breakpoints[breakpoint]
+        const breakpointPixelValue = this.props.breakpoints[breakpoint]
         if (!currentBreakpoint && screenWidth >= breakpointPixelValue) {
           currentBreakpoint = breakpoint
         }
@@ -129,7 +131,7 @@ class ReactBreakpoints extends React.Component {
   }
   getContextValues = () => ({
     breakpoints: {
-      ...this.state.breakpoints,
+      ...this.props.breakpoints,
     },
     ...(this.props.snapMode && {
       currentBreakpoint: this.state.currentBreakpoint,

--- a/modules/ReactBreakpoints.js
+++ b/modules/ReactBreakpoints.js
@@ -47,25 +47,38 @@ class ReactBreakpoints extends React.Component {
      */
     snapMode: PropTypes.bool,
   }
-  state = {
-    breakpoints: this.props.breakpoints || {},
-    screenWidth: global.window
-      ? global.window.innerWidth
-      : this.props.defaultBreakpoint,
-    currentBreakpoint: global.window
-      ? this.calculateCurrentBreakpoint(global.window.innerWidth)
-      : this.props.guessedBreakpoint
-        ? this.calculateCurrentBreakpoint(this.props.guessedBreakpoint)
-        : null,
+
+  constructor(props) {
+    super(props)
+    const { breakpoints, defaultBreakpoint, guessedBreakpoint } = this.props
+
+    // throw Error if no breakpoints were passed
+    if (!breakpoints) throw new Error(ERRORS.NO_BREAKPOINTS)
+    // throw Error if breakpoints is not an object
+    if (typeof breakpoints !== 'object') throw new Error(ERRORS.NOT_OBJECT)
+
+    let currentBreakpoint = null
+
+    // if we are on the client, we directly compote the breakpoint using window width
+    if (global.window) {
+      currentBreakpoint = this.calculateCurrentBreakpoint(
+        global.window.innerWidth,
+      )
+    } else if (guessedBreakpoint) {
+      currentBreakpoint = this.calculateCurrentBreakpoint(guessedBreakpoint)
+    } else if (defaultBreakpoint) {
+      currentBreakpoint = this.calculateCurrentBreakpoint(defaultBreakpoint)
+    }
+    this.state = {
+      breakpoints: breakpoints || {},
+      // if we are on the client, we set the screen width to the window width,
+      // otherwise, we use the default breakpoint
+      screenWidth: global.window ? global.window.innerWidth : defaultBreakpoint,
+      currentBreakpoint: currentBreakpoint,
+    }
   }
 
   componentDidMount() {
-    // throw Error if no breakpoints were passed
-    if (!this.props.breakpoints) throw new Error(ERRORS.NO_BREAKPOINTS)
-    // throw Error if breakpoints is not an object
-    if (typeof this.props.breakpoints !== 'object')
-      throw new Error(ERRORS.NOT_OBJECT)
-
     if (typeof window !== 'undefined') {
       this.readWidth() // initial width calculation
 


### PR DESCRIPTION
I have started to use this package today and I need to support SSR. However, after successfully making it worked on client, I noticed that it wasn't working properly on server-side (only tried with render prop).

Indeed, even by setting the `guessedBreakpoint` property, the `currentBreakpoint` in the render prop was always null on server.

My first step was to set the default `currentBreakpoint` state to  `this.calculateCurrentBreakpoint(this.props.guessedBreakpoint) || null` which was working properly on the server.

However, I found a second issue: even if the rendered breakpoint was `mobile` on the server (value of `guessedBreakpoint`), the first rendered breakpoint in the browser was `null`. This is why I have added the `this.calculateCurrentBreakpoint(global.window.innerWidth)` to the default state value when on the client. 

To make it worked, I had to replace all `this.state.breakpoints` by `this.props.breakpoints` because state wasn't already set when calling `calculateCurrentBreakpoint()`. As far as I understand, there wasn't really a reason to read the breakpoints from the state instead of the props.

I hope this makes sense 🙂 