### PR TITLE
feat: add typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,68 @@
+export interface ReactBreakpointsProps {
+  /**
+   * Your breakpoints object.
+   */
+  breakpoints: { [k: string]: number };
+  /**
+   * The type of unit that your breakpoints should use - px or em.
+   */
+  breakpointUnit?: 'px' | 'em';
+  /**
+   * When rendering on the server, you can do your own magic with for example UA
+   * to guess which viewport width a user probably has.
+   */
+  guessedBreakpoint?: number;
+  /**
+   * In case you don't want to default to mobile on SSR and no guessedBreakpoint
+   * is passed, use defaultBreakpoint to set your own value.
+   */
+  defaultBreakpoint?: number;
+  /**
+   * If you don't want the resize listener to be debounced, set to false. Defaults to false
+   * when snapMode is true.
+   */
+  debounceResize?: boolean;
+  /**
+   * Set a custom delay for how long the debounce timeout should be.
+   */
+  debounceDelay?: number;
+  /**
+   * Replaces breakpoints.current with screenWidth, disabling re-render only
+   * when breakpoint changes, instead potentially re-rendering when 
+   * calculateCurrentBreakpoint returns a new value.
+   */
+  snapMode?: boolean;
+}
+
+/**
+ * Pass in the keys of your breakpoints as K
+ */
+export interface WithBreakpointsProps<K> {
+  breakpoints: { [key in K]: number };
+  currentBreakpoint?: K;
+  screenWidth?: number;
+}
+
+/**
+ * HOC for providing breakpoints as props
+ */
+export declare function withBreakpoints<P = any>(C: React.ComponentType<P>): React.ComponentType<P>;
+
+// Media Component unfortunately can't use Abstract types like in
+// the withBreakPoints because it's type is React.Consumer and it only
+// accepts 1 Abstract type for the props. So using generic types
+// is the only sane solution for now.
+
+/**
+ * React Component providing breakpoints using Render Props
+ */
+export declare const Media: React.Consumer<{
+  breakpoints: { [key: string]: number };
+  currentBreakpoint?: string;
+  screenWidth?: number;
+}>;
+
+
+declare const ReactBreakpoints: React.ComponentClass<ReactBreakpointsProps>;
+
+export default ReactBreakpoints;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.3",
   "description": "A library that allows you to mount/unmount components depending on the viewport size. Welcome to the next level of responsive React applications.",
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/ehellman/react-breakpoints.git"


### PR DESCRIPTION
# TypeScript Support

This PR brings in a `index.d.ts` that provides typescript support. There's full intellisense support when using the `withBreakpoints` HOC. Unfortunately, due to some restrictions on `React.Consumer` type, the `<Media />` component doesn't provide full intellisense support.

## How to use

### `<ReactBreakpoints />`

Usage of `<ReactBreakpoints />` stays the same as in the original docs. Except now you get proper intellisense and prop type checking.

```ts
import * as React from 'react';
import ReactBreakpoints from 'react-breakpoints';

const breakpoints = {
  sm: 100,
  md: 200,
  lg: 300,
}

<ReactBreakpoints breakpoints={breakpoints}>
    <App />
  </ReactBreakpoints>
```
### `withBreakpoints()`

In order to use `withBreakpoints()`, make sure to import `WithBreakpointsProps` and combine them with your component's props. You will want to pass in your breakpoint keys as a type to `WithBreakpointsProps` to get full type hinting and intellisense.

Also, notice the `!` (bang) operator on `currentBreakpoint`. This is because there's a possibility that `currentBreakpoint` and `screenWidth` might be defined or not depending if you set `snapMode` to true or false back in `<ReactBreakpoints  />`

```ts
import * as React from 'react';
import { withBreakpoints, WithBreakpointsProps } from 'react-breakpoints';

const breakpoints = {
  sm: 100,
  md: 200,
  lg: 300,
}

type BPKeys = keyof (typeof breakpoints);

interface IFooProps extends WithBreakpointsProps<BPKeys> { }

const Foo: React.FC<IFooProps> = (props) => {
  const { breakpoints, currentBreakpoint, screenWidth } = props;

  if (breakpoints[currentBreakpoint!] === breakpoints["sm"]) {
    return <p>"its small!"</p>
  }

  if (screenWidth) {
    return <p>"The Screen Width!"</p>
  }

  return null;
};

export default withBreakpoints(Foo);
```

### `<Media />`

Unfortunately I couldn't figure out how to pass in custom props for the React Consumer to use. So I went with using general types for the props. You'll still get proper type checking but no real intellisense :(

If someone can figure out a way to get this working completely then that would be great!

```ts
import * as React from 'react';
import { Media } from 'react-breakpoints';

interface IBarProps { }

const Bar: React.FC<IBarProps> = (props) => {
   return (
    <Media>
      {({ breakpoints, currentBreakpoint }) => {
        if (breakpoints[currentBreakpoint!] === breakpoints["sm"])
          return "sm screen"
       }}
    </Media>
  )
};

```

----

A possible solution for the `<Media />` typings could be something I read a while back about having Generics passed into JSX alongside the component name. I think it's possible due to one of the latest TypeScript release (3.3?). Anyways, the code could look like this:

```ts
type BPKeys = "sm" | "md" | "lg";

// provide BPKeys as abstract type to Media for full intellisense
<Media<BPKeys>>
  {({ breakpoints, currentBreakpoint, screenWidth }) => {
    // ...
  }}
</Media>
```

Don't know if it's possible but just throwing ideas out there.

Lastly, this closes #30.

Edit: This has been tested on my own computer using `npm link` and a separate create-react-app + typescript project. So all the typings work properly :)
