### PR TITLE
change addEventListeners to removeEventListeners

### DIFF
--- a/modules/ReactBreakpoints.js
+++ b/modules/ReactBreakpoints.js
@@ -130,12 +130,12 @@ class ReactBreakpoints extends React.Component {
   componentWillUnmount() {
     if (typeof window !== 'undefined') {
       if (this.props.debounceResize) {
-        window.addEventListener(
+        window.removeEventListener(
           'resize',
           debounce(this.readWidth, this.props.debounceDelay),
         )
       } else {
-        window.addEventListener('resize', this.readWidth)
+        window.removeEventListener('resize', this.readWidth)
       }
       window.removeEventListener('orientationchange', this.readWidth)
     }


### PR DESCRIPTION
noticed that componentWillUnmount includes window.addEventListener when I assumer you mean to be removing them, as you already add them in the mounting method