### PR TITLE
SSR: trust guessedBreakpoint during hydratation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,38 @@ const markup = renderToString(
 )
 ```
 
+In order to avoid mismatch errors (`Warning: Did not expect server HTML to contain ...`), when the guessed breakpoint
+is wrong, you need to provide the same `guessedBreakpoint` on both the server and the client.
+Thanks to this, there will be no error during hydratation and ReactBreakpoint with still render the right 
+breakpoint once the app is mounted.
+```js
+// client.js
+
+import ReactBreakpoints from 'react-breakpoints'
+
+const breakpoints = {
+  mobile: 320,
+  mobileLandscape: 480,
+  tablet: 768,
+  tabletLandscape: 1024,
+  desktop: 1200,
+  desktopLarge: 1500,
+  desktopWide: 1920,
+}
+
+const guessedBreakpoint = window.guessedBreakpoint // you need to inject it from the server
+
+ReactDOM.hydrate(
+  <ReactBreakpoints
+    guessedBreakpoint={guessedBreakpoint}
+    breakpoints={breakpoints}
+  >
+    <App />
+  </ReactBreakpoints>,
+  document.getElementById('root')
+)
+```
+
 ## Options
 
 ### `breakpointUnit: string` option

--- a/modules/ReactBreakpoints.js
+++ b/modules/ReactBreakpoints.js
@@ -68,15 +68,18 @@ class ReactBreakpoints extends React.Component {
     let currentBreakpoint = null
     const sortedBreakpoints = ReactBreakpoints.sortBreakpoints(breakpoints)
 
-    // if we are on the client, we directly compote the breakpoint using window width
-    if (global.window) {
-      currentBreakpoint = ReactBreakpoints.calculateBreakpoint(
-        this.convertScreenWidth(global.window.innerWidth),
-        sortedBreakpoints,
-      )
-    } else if (guessedBreakpoint) {
+    // if there is a guessed breakpoint, we trust it on server AND on client (during hydrate),
+    // to avoid mismatch issues.
+    if (guessedBreakpoint) {
       currentBreakpoint = ReactBreakpoints.calculateBreakpoint(
         guessedBreakpoint,
+        sortedBreakpoints,
+      )
+    }
+    // if we are on the client, we directly compute the breakpoint using window width
+    else if (global.window) {
+      currentBreakpoint = ReactBreakpoints.calculateBreakpoint(
+        this.convertScreenWidth(global.window.innerWidth),
         sortedBreakpoints,
       )
     } else if (defaultBreakpoint) {


### PR DESCRIPTION
As explained in #29, when the breakpoint is wrongly guessed on the server, there is an HTML mismatch during `ReactDom.hydrate()`. When using a CSS-in-JSS technique, this can lead to a completely broken page due to wrong CSS classnames being used.

This PR simply solves this issue by letting the developer set the `guessedBreakpoint` on the client as well. Thanks to this, there will be no mismatch during hydratation. Once the app is hydrated, it will be rerendered using the real breakpoint (during `componentDidMount()` ).

There will be a "blinking" effect on load when switching between the guessed breakpoint and the real one (as with current version), but now, there is no mismatch so no risk of unfortunate side-effects anymore.